### PR TITLE
Fixing newly seen issue: HSS execution is stuck

### DIFF
--- a/build/tools/build_helper.hss_rel14
+++ b/build/tools/build_helper.hss_rel14
@@ -78,6 +78,7 @@ build_c_ares()
 build_cpp_driver()
 {
   pushd $OPENAIRCN_DIR/build/git_submodules/cpp-driver
+  git checkout -f 2.15.0
   rm -rf build
   mkdir -p build
   cd build


### PR DESCRIPTION
See more details at [Issue 104](https://github.com/OPENAIRINTERFACE/openair-cn/issues/104)

Looks like one of the last commits on the cpp-driver submodule may be cause of issue.

The proposed solution is to fix the cpp-driver submodule to tag `2.15.0`