### PR TITLE
CI: fix some cppcheck errors/warnings and remove invalid C++ compile options

### DIFF
--- a/build/hss_rel14/util/Makefile
+++ b/build/hss_rel14/util/Makefile
@@ -8,7 +8,9 @@ OAI_BUILD_DIR := $(OPENAIRCN_DIR)/build/hss_rel14/util
 
 SECURITY_FLAGS := -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fexceptions
 SECURITY_FLAGS += -fstack-protector-all -fstack-protector-strong -Wall
-SECURITY_FLAGS += -Werror=format-security -Werror=implicit-function-declaration
+SECURITY_FLAGS += -Werror=format-security
+# Following option not valid in C++
+#SECURITY_FLAGS += -Werror=implicit-function-declaration
 
 SRCDIR := $(OAI_HSS_UTIL_DIR)/src
 BUILDDIR := $(OAI_BUILD_DIR)/build

--- a/ci-scripts/cppcheck_suppressions.list
+++ b/ci-scripts/cppcheck_suppressions.list
@@ -21,11 +21,4 @@
 // */
 //*****************************************************************************
 //-----------------------------------------------------------------------------
-// is itti analyzer deprecated
-nullPointer:src/common/itti_analyzer/itti_analyzer.c
-nullPointerRedundantCheck:src/common/itti_analyzer/libbuffers/buffers.c
-doubleFree:src/common/itti_analyzer/libbuffers/socket.c
-memleak:src/common/itti_analyzer/libbuffers/socket.c
-memleak:src/common/itti_analyzer/libparser/array_type.c
-memleak:src/common/itti_analyzer/libui/ui_callbacks.c
 // *INDENT-ON*

--- a/src/hss_rel14/smsrouter/src/options.cpp
+++ b/src/hss_rel14/smsrouter/src/options.cpp
@@ -131,12 +131,14 @@ bool Options::parseInputOptions( int argc, char **argv )
                case 'q': { std::cout << "Option -q (log queue size) requires an argument" << std::endl; break; }
                default: { std::cout << "Unrecognized option [" << c << "]" << std::endl; break; }
             }
-            result = false;
+            if (result)
+              result = false;
          }
          default:
          {
             std::cout << "Unrecognized option [" << c << "]" << std::endl;
-            result = false;
+            if (result)
+              result = false;
          }
       }
    }

--- a/src/hss_rel14/src/dataaccess.cpp
+++ b/src/hss_rel14/src/dataaccess.cpp
@@ -997,7 +997,7 @@ bool DataAccess::checkOpcKeys( const uint8_t opP[16] )
 
          std::string newopc = Utility::bytes2hex(opccalc, OPC_LENGTH);
 
-         Logger::system().info("COUNT: %d IMSI: %s KEY: %s OPC: %s NEW OPC: %s", ++cnt, imsi, key, opc, newopc);
+         Logger::system().info("COUNT: %d IMSI: %s KEY: %s OPC: %s NEW OPC: %s", ++cnt, (uint8_t *)imsi.c_str(), (uint8_t *)key.c_str(), (uint8_t *)opc.c_str(), (uint8_t *)newopc.c_str());
 
          if( !updateOpc(imsi, newopc) ) {
             return false;

--- a/src/hss_rel14/src/main.cpp
+++ b/src/hss_rel14/src/main.cpp
@@ -63,7 +63,7 @@ void handler(int signal)
       size_t cnt = fdHss.getWorkerQueue().queueDepth();
 
       if (cnt > 0)
-         printf("pending messages %lu\n", cnt);
+         printf("pending messages %lu\n", (unsigned long) cnt);
    }
    else
    {

--- a/src/hss_rel14/src/main.cpp
+++ b/src/hss_rel14/src/main.cpp
@@ -63,7 +63,7 @@ void handler(int signal)
       size_t cnt = fdHss.getWorkerQueue().queueDepth();
 
       if (cnt > 0)
-         printf("pending messages %ld\n", cnt);
+         printf("pending messages %lu\n", cnt);
    }
    else
    {

--- a/src/hss_rel14/util/src/fd.cpp
+++ b/src/hss_rel14/util/src/fd.cpp
@@ -1242,14 +1242,19 @@ FDAvp FDMessage::getFirstAVP( bool &found )
       ret = fd_msg_model( child, &model );
       if ( ret != 0 )
          throw FDException(
-            SUtility::string_format("%s:%d - INFO - unalbe to regrieve avp model",
+            SUtility::string_format("%s:%d - INFO - unable to retrieve avp model",
             __FILE__, __LINE__, ret )
          );
 
       de = new FDDictionaryEntryAVP( model );
       return FDAvp( *de, child, true );
+   } else {
+      ret = -1;
+      throw FDException(
+         SUtility::string_format("%s:%d - INFO - unable to retrieve avp model",
+         __FILE__, __LINE__, ret )
+      );
    }
-   return FDAvp( NULL, child, true );
 }
 
 void FDMessage::dump()

--- a/src/hss_rel14/util/src/fd.cpp
+++ b/src/hss_rel14/util/src/fd.cpp
@@ -1247,8 +1247,9 @@ FDAvp FDMessage::getFirstAVP( bool &found )
          );
 
       de = new FDDictionaryEntryAVP( model );
+      return FDAvp( *de, child, true );
    }
-   return FDAvp( *de, child, true );
+   return FDAvp( NULL, child, true );
 }
 
 void FDMessage::dump()

--- a/src/hss_rel14/util/src/fdjson.cpp
+++ b/src/hss_rel14/util/src/fdjson.cpp
@@ -308,7 +308,13 @@ public:
 
    struct avp *getAvp() { return mAvp; }
 
-   void allocBuffer(size_t len) { if (mBuff == NULL) {mBuf = new Buffer<uint8_t>(len); }}
+   void allocBuffer(size_t len)
+   {
+      if (mBuf) {
+        delete mBuf;
+      }
+      mBuf = new Buffer<uint8_t>(len);
+   }
    Buffer<uint8_t> &getBuffer() { return *mBuf; }
 
    dict_avp_basetype getBaseType() { return mBaseData.avp_basetype; }

--- a/src/hss_rel14/util/src/fdjson.cpp
+++ b/src/hss_rel14/util/src/fdjson.cpp
@@ -308,7 +308,7 @@ public:
 
    struct avp *getAvp() { return mAvp; }
 
-   void allocBuffer(size_t len) { mBuf = new Buffer<uint8_t>(len); }
+   void allocBuffer(size_t len) { if (mBuff == NULL) {mBuf = new Buffer<uint8_t>(len); }}
    Buffer<uint8_t> &getBuffer() { return *mBuf; }
 
    dict_avp_basetype getBaseType() { return mBaseData.avp_basetype; }


### PR DESCRIPTION
After code clean-up:

- Remove obsolete exceptions for cppcheck
- Fix a few warnings/errors detected by cppckeck
- Remove the C++ invalid option: `-Werror=implicit-function-declaration`