### PR TITLE
CI: adding CLANG-FORMAT checker to pipeline

### DIFF
--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -190,7 +190,8 @@ pipeline {
               myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
               myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "rm -f /home/openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
 
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
+              // We install a dedicated version (installed on our CI server).
+              myShCmd('docker cp /opt/clang-format/9.0.0/bin/clang-format ci-cn-clang-formatter:/usr/local/bin', new_host_flag, new_host_user, new_host)
               if (env.ghprbPullId != null) {
                 myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh --src-branch ' + env.ghprbSourceBranch +' --target-branch ' + env.ghprbTargetBranch + '"', new_host_flag, new_host_user, new_host)
               } else {

--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -202,6 +202,8 @@ pipeline {
           post {
             always {
               script {
+                myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result.txt src', new_host_flag, new_host_user, new_host)
+                myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result_list.txt src', new_host_flag, new_host_user, new_host)
                 copyFrom2ndServer('archives/clang_format*.*', 'archives', new_host_flag, new_host_user, new_host)
                 copyFrom2ndServer('src/oai_rules*.*', 'src', new_host_flag, new_host_user, new_host)
               }

--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -178,6 +178,35 @@ pipeline {
             }
           }
         }
+        // Running CLANG-FORMATTING check in parallel to gain time
+        stage ('Code Formatting Checker') {
+          steps {
+            script {
+              myShCmd('docker run --name ci-cn-clang-formatter -d ubuntu:bionic /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
+              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
+              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "apt-get install --yes git tree clang-format bzip2" >> archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
+
+              myShCmd('docker cp ./openair-hss.tar.bz2 ci-cn-clang-formatter:/home', new_host_flag, new_host_user, new_host)
+              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
+              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "rm -f /home/openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
+
+              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-hss.tar.bz2"', new_host_flag, new_host_user, new_host)
+              if (env.ghprbPullId != null) {
+                myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh --src-branch ' + env.ghprbSourceBranch +' --target-branch ' + env.ghprbTargetBranch + '"', new_host_flag, new_host_user, new_host)
+              } else {
+                myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh"', new_host_flag, new_host_user, new_host)
+              }
+            }
+          }
+          post {
+            always {
+              script {
+                copyFrom2ndServer('archives/clang_format*.*', 'archives', new_host_flag, new_host_user, new_host)
+                copyFrom2ndServer('src/oai_rules*.*', 'src', new_host_flag, new_host_user, new_host)
+              }
+            }
+          }
+        }
       }
     }
     stage('Deploy Full EPC') {

--- a/ci-scripts/checkCodingFormattingRules.sh
+++ b/ci-scripts/checkCodingFormattingRules.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#/*
+# * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# * contributor license agreements.  See the NOTICE file distributed with
+# * this work for additional information regarding copyright ownership.
+# * The OpenAirInterface Software Alliance licenses this file to You under
+# * the OAI Public License, Version 1.1  (the "License"); you may not use this file
+# * except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *      http://www.openairinterface.org/?page_id=698
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *-------------------------------------------------------------------------------
+# * For more information about the OpenAirInterface (OAI) Software Alliance:
+# *      contact@openairinterface.org
+# */
+
+function usage {
+    echo "OAI Coding / Formatting Guideline Check script"
+    echo "   Original Author: Raphael Defosseux"
+    echo ""
+    echo "   Requirement: clang-format / git shall be installed"
+    echo ""
+    echo "   By default (no options) the complete repository will be checked"
+    echo "   In case of merge/pull request, provided source and target branch,"
+    echo "   the script will check only the modified files"
+    echo ""
+    echo "Usage:"
+    echo "------"
+    echo "    checkCodingFormattingRules.sh [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "--------"
+    echo "    --src-branch #### OR -sb ####"
+    echo "    Specify the source branch of the merge request."
+    echo ""
+    echo "    --target-branch #### OR -tb ####"
+    echo "    Specify the target branch of the merge request (usually develop)."
+    echo ""
+    echo "    --help OR -h"
+    echo "    Print this help message."
+    echo ""
+}
+
+if [ $# -ne 4 ] && [ $# -ne 1 ] && [ $# -ne 0 ]
+then
+    echo "Syntax Error: not the correct number of arguments"
+    echo ""
+    usage
+    exit 1
+fi
+
+cd src
+
+if [ $# -eq 0 ]
+then
+    echo " ---- Checking the whole repository ----"
+    echo ""
+    if [ -f oai_rules_result.txt ]
+    then
+        rm -f oai_rules_result.txt
+    fi
+    if [ -f oai_rules_result_list.txt ]
+    then
+        rm -f oai_rules_result_list.txt
+    fi
+    EXTENSION_LIST=("h" "c" "cpp")
+    NB_TO_FORMAT=0
+    for EXTENSION in ${EXTENSION_LIST[@]}
+    do
+        echo "Checking for all files with .${EXTENSION} extension"
+        FILE_LIST=`tree -n --noreport -i -f -P *.${EXTENSION} | sed -e 's#^\./##' | grep "\.${EXTENSION}"`
+        for FILE_TO_CHECK in ${FILE_LIST[@]}
+        do
+            TO_FORMAT=`clang-format -verbose -output-replacements-xml ${FILE_TO_CHECK} 2>&1 | grep -c Formatting`
+            NB_TO_FORMAT=$((NB_TO_FORMAT + TO_FORMAT))
+            if [ $TO_FORMAT -ne 0 ]
+            then
+                # In case of full repo, being silent
+                #echo "src/$FILE_TO_CHECK"
+                echo "src/$FILE_TO_CHECK" >> ./oai_rules_result_list.txt
+            fi
+        done
+    done
+    #NB_FILES_TO_FORMAT=`astyle --dry-run --options=ci-scripts/astyle-options.txt --recursive *.c *.h | grep -c Formatted `
+    echo "Nb Files that do NOT follow OAI rules: $NB_TO_FORMAT"
+    echo $NB_TO_FORMAT > ./oai_rules_result.txt
+    exit 0
+fi
+
+checker=0
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h|--help)
+    shift
+    usage
+    exit 0
+    ;;
+    -sb|--src-branch)
+    SOURCE_BRANCH="$2"
+    let "checker|=0x1"
+    shift
+    shift
+    ;;
+    -tb|--target-branch)
+    TARGET_BRANCH="$2"
+    let "checker|=0x2"
+    shift
+    shift
+    ;;
+    *)
+    echo "Syntax Error: unknown option: $key"
+    echo ""
+    usage
+    exit 1
+esac
+
+done
+
+
+if [ $checker -ne 3 ]
+then
+    echo "Source Branch is    : $SOURCE_BRANCH"
+    echo "Target Branch is    : $TARGET_BRANCH"
+    echo ""
+    echo "Syntax Error: missing option"
+    echo ""
+    usage
+    exit 1
+fi
+
+# Merge request scenario
+
+MERGE_COMMMIT=`git log -n1 --pretty=format:%H`
+TARGET_INIT_COMMIT=`cat .git/refs/remotes/origin/$TARGET_BRANCH`
+
+echo " ---- Checking the modified files by the merge request ----"
+echo ""
+echo "Source Branch is    : $SOURCE_BRANCH"
+echo "Target Branch is    : $TARGET_BRANCH"
+echo "Merged Commit is    : $MERGE_COMMMIT"
+echo "Target Init   is    : $TARGET_INIT_COMMIT"
+echo ""
+echo " ----------------------------------------------------------"
+echo ""
+
+# Retrieve the list of modified files since the latest develop commit
+MODIFIED_FILES=`git log $TARGET_INIT_COMMIT..$MERGE_COMMMIT --oneline --name-status | egrep "^M|^A" | sed -e "s@^M\t*@@" -e "s@^A\t*@@" | sort | uniq`
+NB_TO_FORMAT=0
+exit 0
+
+
+if [ -f oai_rules_result_list.txt ]
+then
+    rm -f oai_rules_result_list.txt
+fi
+for FULLFILE in $MODIFIED_FILES
+do
+    filename=$(basename -- "$FULLFILE")
+    EXT="${filename##*.}"
+    if [ $EXT = "c" ] || [ $EXT = "h" ] || [ $EXT = "cpp" ] || [ $EXT = "hpp" ]
+    then
+        TO_FORMAT=`astyle --dry-run --options=ci-scripts/astyle-options.txt $FULLFILE | grep -c Formatted `
+        NB_TO_FORMAT=$((NB_TO_FORMAT + TO_FORMAT))
+        if [ $TO_FORMAT -ne 0 ]
+        then
+            echo $FULLFILE
+            echo $FULLFILE >> ./oai_rules_result_list.txt
+        fi
+    fi
+done
+echo ""
+echo " ----------------------------------------------------------"
+echo "Nb Files that do NOT follow OAI rules: $NB_TO_FORMAT"
+echo $NB_TO_FORMAT > ./oai_rules_result.txt
+
+exit 0

--- a/ci-scripts/generateHtmlReport.py
+++ b/ci-scripts/generateHtmlReport.py
@@ -44,6 +44,8 @@ class HtmlReport():
 		self.file = open(cwd + '/test_results_oai_hss.html', 'w')
 		self.generateHeader()
 
+		self.coding_formatting_log()
+
 		self.analyze_sca_log()
 
 		self.buildSummaryHeader()
@@ -162,6 +164,47 @@ class HtmlReport():
 		self.file.write('  <div class="well well-lg">End of Build Report -- Copyright <span class="glyphicon glyphicon-copyright-mark"></span> 2020 <a href="http://www.openairinterface.org/">OpenAirInterface</a>. All Rights Reserved.</div>\n')
 		self.file.write('</div></body>\n')
 		self.file.write('</html>\n')
+
+	def coding_formatting_log(self):
+		cwd = os.getcwd()
+		self.file.write('  <h2>OAI Coding / Formatting Guidelines Check</h2>\n')
+		if os.path.isfile(cwd + '/src/oai_rules_result.txt'):
+			cmd = 'cat ' + cwd + '/src/oai_rules_result.txt'
+			ret = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+			if int(ret.strip()) == 0:
+				self.file.write('  <div class="alert alert-success">\n')
+				if self.git_pull_request:
+					self.file.write('    <strong>All modified files in Pull-Request follow OAI rules. <span class="glyphicon glyphicon-ok-circle"></span></strong>\n')
+				else:
+					self.file.write('    <strong>All files in repository follow OAI rules. <span class="glyphicon glyphicon-ok-circle"></span></strong>\n')
+				self.file.write('  </div>\n')
+			else:
+				self.file.write('  <div class="alert alert-warning">\n')
+				if self.git_pull_request:
+					self.file.write('    <strong>' + ret.strip() + ' modified files in Pull-Request DO NOT follow OAI rules. <span class="glyphicon glyphicon-warning-sign"></span></strong>\n')
+				else:
+					self.file.write('    <strong>' + ret.strip() + ' files in repository DO NOT follow OAI rules. <span class="glyphicon glyphicon-warning-sign"></span></strong>\n')
+				self.file.write('  </div>\n')
+
+				if os.path.isfile(cwd + '/src/oai_rules_result_list.txt'):
+					self.file.write('  <button data-toggle="collapse" data-target="#oai-formatting-details">More details on formatting check</button>\n')
+					self.file.write('  <div id="oai-formatting-details" class="collapse">\n')
+					self.file.write('  <p>Please apply the following command to this(ese) file(s): </p>\n')
+					self.file.write('  <p style="margin-left: 30px"><strong><code>cd src && clang-format -i filename(s)</code></strong></p>\n')
+					self.file.write('  <table class="table-bordered" width = "60%" align = "center" border = 1>\n')
+					self.file.write('    <tr><th bgcolor = "lightcyan" >Filename</th></tr>\n')
+					with open(cwd + '/src/oai_rules_result_list.txt', 'r') as filelist:
+						for line in filelist:
+							self.file.write('    <tr><td>' + line.strip() + '</td></tr>\n')
+						filelist.close()
+					self.file.write('  </table>\n')
+					self.file.write('  </div>\n')
+		else:
+			self.file.write('  <div class="alert alert-danger">\n')
+			self.file.write('	  <strong>Was NOT performed (with CLANG-FORMAT tool). <span class="glyphicon glyphicon-ban-circle"></span></strong>\n')
+			self.file.write('  </div>\n')
+
+		self.file.write('  <br>\n')
 
 	def analyze_sca_log(self):
 		cwd = os.getcwd()

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,117 +1,117 @@
----
-Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
+#
+# Copyright (c) 2015, EURECOM (www.eurecom.fr)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+#
+
+# see https://clang.llvm.org/docs/ClangFormatStyleOptions.html for explanation
+# of style options
+
+BasedOnStyle: Google
+Language: Cpp
+IndentWidth: 2
+ColumnLimit: 80
+
+IncludeBlocks: Preserve
+SortIncludes: false
+
+# alignment
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-AlignOperands:   true
+AlignEscapedNewlines: Right
+AlignOperands: true
 AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# function style
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: Inline
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:   
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
+IndentWrappedFunctionNames: false
+
+# template style
+AlwaysBreakTemplateDeclarations: Yes
+
+# preprocessor style
+IndentPPDirectives: None
+
+# block style
+AllowShortBlocksOnASingleLine: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# break style
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
+BreakBeforeTernaryOperators: false
 BreakStringLiterals: true
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:   
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Preserve
-IncludeCategories: 
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
-IndentPPDirectives: None
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
+ReflowComments: true
+
+# spacing style
+UseTab: Never
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
+SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Auto
-TabWidth:        8
-UseTab:          Never
-...
 
+# class style
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+
+# case statements
+IndentCaseLabels: true
+
+# cpp
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+NamespaceIndentation: None
+SortUsingDeclarations: true
+
+# todo
+# AlwaysBreakBeforeMultilineStrings: bool
+# PenaltyBreakAssignment (unsigned)
+# PenaltyBreakBeforeFirstCallParameter (unsigned)
+# PenaltyBreakComment (unsigned)
+# PenaltyBreakFirstLessLess (unsigned)
+# PenaltyBreakString (unsigned)
+# PenaltyBreakTemplateDeclaration (unsigned)
+# PenaltyExcessCharacter (unsigned)
+# PenaltyReturnTypeOnItsOwnLine (unsigned)


### PR DESCRIPTION
-  Added .clang-format file from the MAGMA project
-  Added a script that either checks all files in repo (src folder only) or the modified files by the pull request
- Added pipeline stage to execute in a container
   * Install dedicated version of clang-format (v9.0.0)
- Notification in the HTML report (non-blocking so we can keep executing build and tests)

Pipeline will be active only when PR is merged into `develop` branch.

Once this is validated on this repository, we will propagate to other repos.