### PR TITLE
Disable default "make -j" for compiling third party libraries, parall…

### DIFF
--- a/build/tools/build_helper
+++ b/build/tools/build_helper
@@ -44,9 +44,13 @@ if [ $IS_CONTAINER -eq 0 ]
 then
   SUDO='sudo -S -E'
 else
-  SUDO=''
+  if [ -v FORCE_SUDO ]
+  then
+    SUDO='sudo'
+  else
+    SUDO=''
+  fi
 fi
-
 ###############################
 ## echo and  family
 ###############################
@@ -82,7 +86,7 @@ echo_info()    { cecho "$*" $blue         ;}
 
 #-------------------------------------------------------------------------------
 # From https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
-# arg1 is a dotted (or not) version number (ex 4.10.6.56-ubunutu) 
+# arg1 is a dotted (or not) version number (ex 4.10.6.56-ubunutu)
 # arg2 is a dotted (or not) version number (ex 4.10.6.56-ubunutu)
 # return 0 if $1 lower or equal $2, else 1
 version_le() {
@@ -162,7 +166,7 @@ clean_kernel() {
 clean_all_files() {
   set_openair_env
   dir=$OPENAIRCN_DIR/build
-  rm -rf $dir/log 
+  rm -rf $dir/log
   rm -rf $dir/spgw/build $dir/spgw/CMakeLists.txt
   rm -rf $dir/mme/build $dir/mme/CMakeLists.txt
   rm -rf $dir/hss/build
@@ -181,8 +185,8 @@ disable_ipv6() {
 # arg2 = req_version
 #
 
-function version_gt() { 
-  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; 
+function version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
 }
 
 
@@ -957,7 +961,7 @@ set_virtual_interface_up(){
     return 1;
   fi
   case $interface in
-    *:*) 
+    *:*)
       $SUDO ifconfig  $interface $address up
       return $?
     ;;
@@ -971,11 +975,11 @@ set_virtual_interface_up(){
 set_cn_virtual_interfaces(){
   if [ "$#" -eq 1 ]; then
 
-    declare -a if_arr=("MME_INTERFACE_NAME_FOR_S1_MME" "MME_INTERFACE_NAME_FOR_S11" "MME_INTERFACE_NAME_FOR_S10" 
-                  "SGW_INTERFACE_NAME_FOR_S11" "SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP" "SGW_INTERFACE_NAME_FOR_S5_S8_UP" 
+    declare -a if_arr=("MME_INTERFACE_NAME_FOR_S1_MME" "MME_INTERFACE_NAME_FOR_S11" "MME_INTERFACE_NAME_FOR_S10"
+                  "SGW_INTERFACE_NAME_FOR_S11" "SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP" "SGW_INTERFACE_NAME_FOR_S5_S8_UP"
                   "PGW_INTERFACE_NAME_FOR_S5_S8" "PGW_INTERFACE_NAME_FOR_SGI")
-                  
-    declare -a ip_arr=("MME_IPV4_ADDRESS_FOR_S1_MME" "MME_IPV4_ADDRESS_FOR_S11" "MME_IPV4_ADDRESS_FOR_S10" 
+
+    declare -a ip_arr=("MME_IPV4_ADDRESS_FOR_S1_MME" "MME_IPV4_ADDRESS_FOR_S11" "MME_IPV4_ADDRESS_FOR_S10"
                   "SGW_IPV4_ADDRESS_FOR_S11" "SGW_IPV4_ADDRESS_FOR_S1U_S12_S4_UP" "SGW_IPV4_ADDRESS_FOR_S5_S8_UP"
                   "PGW_IPV4_ADDRESS_FOR_S5_S8" "PGW_IPV4_ADDRESS_FOR_SGI")
     for ((i=0; i<${#if_arr[@]}; ++i)); do
@@ -984,32 +988,32 @@ set_cn_virtual_interfaces(){
       unset $if_name
       unset $ip_address
     done
-  
+
     value="`cat $1 | cut -d "#" -f1 | cut -d "}" -f1 | cut -d "{" -f2 | grep 'ADDRESS\|INTERFACE' | tr -d " " | grep "="`"
     eval $value
 
-    declare -a if_arr=("MME_INTERFACE_NAME_FOR_S1_MME" "MME_INTERFACE_NAME_FOR_S11" "MME_INTERFACE_NAME_FOR_S10" 
-                  "SGW_INTERFACE_NAME_FOR_S11" "SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP" "SGW_INTERFACE_NAME_FOR_S5_S8_UP" 
+    declare -a if_arr=("MME_INTERFACE_NAME_FOR_S1_MME" "MME_INTERFACE_NAME_FOR_S11" "MME_INTERFACE_NAME_FOR_S10"
+                  "SGW_INTERFACE_NAME_FOR_S11" "SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP" "SGW_INTERFACE_NAME_FOR_S5_S8_UP"
                   "PGW_INTERFACE_NAME_FOR_S5_S8" "PGW_INTERFACE_NAME_FOR_SGI")
-                  
-    declare -a ip_arr=("MME_IPV4_ADDRESS_FOR_S1_MME" "MME_IPV4_ADDRESS_FOR_S11" "MME_IPV4_ADDRESS_FOR_S10" 
+
+    declare -a ip_arr=("MME_IPV4_ADDRESS_FOR_S1_MME" "MME_IPV4_ADDRESS_FOR_S11" "MME_IPV4_ADDRESS_FOR_S10"
                   "SGW_IPV4_ADDRESS_FOR_S11" "SGW_IPV4_ADDRESS_FOR_S1U_S12_S4_UP" "SGW_IPV4_ADDRESS_FOR_S5_S8_UP"
                   "PGW_IPV4_ADDRESS_FOR_S5_S8" "PGW_IPV4_ADDRESS_FOR_SGI")
 
     for ((i=0; i<${#if_arr[@]}; ++i)); do
       if_name=${if_arr[i]}
-      ip_address=${ip_arr[i]}      
+      ip_address=${ip_arr[i]}
       if [ -n "$${if_name}" ]; then
         case ${!if_name} in
-          *:*) 
+          *:*)
             if [ -n "$${ip_address}" ]; then
               echo_success "Configuring ${!if_name}  ${!ip_address}"
-              set_virtual_interface_up  ${!if_name}  ${!ip_address} 
+              set_virtual_interface_up  ${!if_name}  ${!ip_address}
               [[ $? -ne 0 ]] && return $?
             else
               echo_error "$ip_address does not exist in your config file $1, but $if_name does!"
               return 1
-            fi  
+            fi
             ;;
         esac
       fi

--- a/build/tools/build_helper.fd
+++ b/build/tools/build_helper.fd
@@ -78,7 +78,7 @@ remove_nettle_from_source() {
   nettle_uninstall_log=$OPENAIRCN_DIR/build/log/nettle_uninstall_log.txt
   #echo_info "\nUn-Installing Nettle from sources. The log file for nettle un-installation is here: $nettle_uninstall_log "
   (
-    $SUDO apt-get remove -y nettle-dev nettle-bin 
+    $SUDO apt-get remove -y nettle-dev nettle-bin
     cd /tmp
     echo "Downloading nettle archive"
     $SUDO rm -rf /tmp/nettle-2.5.tar.gz* /tmp/nettle-2.5
@@ -93,8 +93,8 @@ remove_nettle_from_source() {
     fi
     tar -xzf nettle-2.5.tar.gz
     cd nettle-2.5/
-    ./configure --disable-openssl --enable-shared --prefix=/usr 
-    $SUDO make uninstall || true 
+    ./configure --disable-openssl --enable-shared --prefix=/usr
+    $SUDO make uninstall || true
   ) >& $nettle_uninstall_log
   return 0
 }
@@ -107,7 +107,7 @@ remove_gnutls_from_source(){
   #echo_info "\nUn-Installing Gnutls. The log file for Gnutls un-installation is here: $gnutls_uninstall_log "
   (
     $SUDO apt-get remove -y libgnutls-dev
-    cd /tmp 
+    cd /tmp
     echo "Downloading gnutls archive"
     $SUDO rm -rf /tmp/gnutls-3.1.23.tar.xz* /tmp/gnutls-3.1.23
     wget http://mirrors.dotsrc.org/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz || \
@@ -180,7 +180,7 @@ install_1.1.5_freediameter_from_source() {
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ../
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     echo "Compiling freeDiameter"
-    make -j`nproc`
+    make $JNPROC
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     #make test
     $SUDO make install
@@ -276,7 +276,7 @@ install_freediameter_from_source() {
     cd build
     $CMAKE -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../
     ret=$?;[[ $ret -ne 0 ]] && return $ret
-    make -j`nproc`
+    make $JNPROC
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     #make test
     $SUDO make install
@@ -335,7 +335,7 @@ install_latest_freediameter_from_source() {
     cd build
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ../
     echo "Compiling freeDiameter"
-    make -j`nproc`
+    make $JNPROC
     #make test
     $SUDO make install
     cd /tmp
@@ -421,7 +421,7 @@ install_opencoord.org_freediameter() {
       echo_info "Detected freeDiameter $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch alredy applied"
     fi
     ret=$?;[[ $ret -ne 0 ]] && return $ret
-  
+
     rm -rf build
     mkdir -p build
     cd build
@@ -429,7 +429,7 @@ install_opencoord.org_freediameter() {
     res=$?
     [[ $res -ne 0 ]] && popd && return $res
     awk '{if (/^DISABLE_SCTP/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt
-    make -j`nproc`
+    make $JNPROC
     res=$?
     [[ $res -ne 0 ]] && popd && return $res
     $SUDO make install

--- a/scripts/build_hss_rel14
+++ b/scripts/build_hss_rel14
@@ -3,9 +3,9 @@
 # Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
-# The OpenAirInterface Software Alliance licenses this file to You under 
+# The OpenAirInterface Software Alliance licenses this file to You under
 # the Apache License, Version 2.0  (the "License"); you may not use this file
-# except in compliance with the License.  
+# except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
@@ -46,6 +46,7 @@ function help()
   echo_error "  -f, --force                               No interactive script for installation of software packages."
   echo_error "  -h, --help                                Print this help."
   echo_error "  -i, --check-installed-software            Check installed software packages necessary to build and run HSS (support $SUPPORTED_DISTRO)."
+  echo_error "  -j, --jobs                                Multiple jobs for compiling."
   echo_error "                                            If filled, then OPc key in table users for all subscribers (IMSI) will be computed/updated."
   echo_error "  -v, --verbose                             Build process verbose."
 }
@@ -57,7 +58,7 @@ function main()
   local -i var_check_install_oai_software=0
   local -i force=0
   local    cmake_args=" "
-  local    make_args="-j`nproc`"
+  export make_args=" "
   local    realm=""
 
   until [ -z "$1" ]; do
@@ -94,6 +95,13 @@ function main()
         var_check_install_oai_software=1
         shift;
         ;;
+      -j | --jobs)
+        # JNPROC used in build of 3rd party libraries
+        export JNPROC="-j`nproc`"
+        # used in building OAI executable
+        make_args="$make_args -j`nproc`"
+        shift;
+        ;;
       -v | --verbose)
         echo "Make build process verbose"
         cmake_args="$cmake_args -DCMAKE_VERBOSE_MAKEFILE=ON"
@@ -101,7 +109,7 @@ function main()
         verbose=1
         shift;
         ;;
-      *)   
+      *)
         echo "Unknown option $1"
         help
         return 1
@@ -123,7 +131,7 @@ function main()
   if [ $var_check_install_oai_software -gt 0 ];then
     update_package_db
     [[ $? -ne 0 ]] && return $?
-    
+
     check_install_hss_software  $force
     if [ $? -ne 0 ]; then
         echo_error "Error: HSS software installation failed"
@@ -139,7 +147,7 @@ function main()
   if [[ $verbose -eq 1 ]]; then
     cecho "OPENAIRCN_DIR    = $OPENAIRCN_DIR" $green
   fi
-  
+
   if [[ z$OPENAIRCN_DIR = z ]]; then
     echo_error "OPENAIRCN_DIR env variable not set, exiting"
     return 1
@@ -153,7 +161,7 @@ function main()
 
   cmake_args="$cmake_args -DOPENAIRCN_DIR=$OPENAIRCN_DIR"
 
-  build_util 
+  build_util
   ret=$?;[[ $ret -ne 0 ]] && return $ret
   build_hsssec
   ret=$?;[[ $ret -ne 0 ]] && return $ret

--- a/scripts/build_hss_rel14
+++ b/scripts/build_hss_rel14
@@ -58,7 +58,7 @@ function main()
   local -i var_check_install_oai_software=0
   local -i force=0
   local    cmake_args=" "
-  export make_args=" "
+  local    make_args="-j`nproc`"
   local    realm=""
 
   until [ -z "$1" ]; do
@@ -132,10 +132,10 @@ function main()
     update_package_db
     [[ $? -ne 0 ]] && return $?
 
-    check_install_hss_software  $force
-    if [ $? -ne 0 ]; then
+    ret=$(check_install_hss_software  $force)
+    if [ $ret -ne 0 ]; then
         echo_error "Error: HSS software installation failed"
-        return 1
+        return $ret
     else
         echo_success "HSS software installation successful"
         echo "HSS not compiled, to compile it, re-run build_hss without -i option"


### PR DESCRIPTION
Disable default "make -j" for compiling third party libraries, parallel build fails sometimes in containers (warn dead code)