### PR TITLE
Added missing files to build Cassandra

### DIFF
--- a/build/tools/build_helper.cassandra
+++ b/build/tools/build_helper.cassandra
@@ -1,0 +1,86 @@
+################################################################################
+# Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The OpenAirInterface Software Alliance licenses this file to You under
+# the Apache License, Version 2.0  (the "License"); you may not use this file
+# except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# For more information about the OpenAirInterface (OAI) Software Alliance:
+#      contact@openairinterface.org
+################################################################################
+
+# file build_helper.cassandra
+# brief
+# author Tien-Thinh Nguyen, Lionel GAUTHIER
+#
+#######################################
+################################
+# include helper functions
+################################
+SCRIPT=$(readlink -f ${BASH_SOURCE})
+THIS_CASS_SCRIPT_PATH=`dirname $SCRIPT`
+source $THIS_CASS_SCRIPT_PATH/build_helper
+
+#-------------------------------------------------------------------------------
+check_install_cassandra_software() {
+  if [ $1 -eq 0 ]; then
+    OPTION=""
+    read -p "Do you want to install cassandra ? <y/N> " prompt
+  else
+    prompt='y'
+    OPTION="-y"
+  fi
+
+  if [[ $prompt =~ [yY](es)* ]]
+  then
+    $SUDO add-apt-repository -y ppa:webupd8team/java
+    ret=$?;[[ $ret -ne 0 ]] && return $ret
+    $SUDO apt-get update
+    local PROXY_DISABLED=0
+    if [ -f /etc/apt/apt.conf.d/01proxy ]
+    then
+        PROXY_DISABLED=1
+        $SUDO mv /etc/apt/apt.conf.d/01proxy /tmp
+    fi
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | $SUDO /usr/bin/debconf-set-selections
+    # install Java 8
+    $SUDO $INSTALLER install $OPTION curl openjdk-8-jre
+    if [ $PROXY_DISABLED -eq 1 ]
+    then
+        $SUDO mv /tmp/01proxy /etc/apt/apt.conf.d
+    fi
+
+    echo "deb http://www.apache.org/dist/cassandra/debian 21x main" | $SUDO  tee -a /etc/apt/sources.list.d/cassandra.sources.list
+    curl https://downloads.apache.org/cassandra/KEYS | $SUDO  apt-key add -
+    ret=$?;[[ $ret -ne 0 ]] && return $ret
+    $SUDO apt-get update
+    ret=$?;[[ $ret -ne 0 ]] && return $ret
+    $SUDO $INSTALLER install $OPTION cassandra
+    return $?
+  else 
+    return 1
+  fi
+}
+
+
+#-------------------------------------------------------------------------------
+clean_log_cassandra() {
+
+  $SUDO service cassandra stop
+  ret=$?;[[ $ret -ne 0 ]] && echo_error "no known cassandra service seems to be configured on this host" && return $ret
+  $SUDO rm -rf /var/lib/cassandra/data/system/*
+  $SUDO rm -rf /var/lib/cassandra/commitlog/*
+  $SUDO rm -rf /var/lib/cassandra/data/system_traces/*
+  $SUDO rm -rf /var/lib/cassandra/saved_caches/*
+  return 0
+}

--- a/scripts/build_cassandra
+++ b/scripts/build_cassandra
@@ -1,0 +1,150 @@
+#!/bin/bash
+################################################################################
+# Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The OpenAirInterface Software Alliance licenses this file to You under 
+# the Apache License, Version 2.0  (the "License"); you may not use this file
+# except in compliance with the License.  
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# For more information about the OpenAirInterface (OAI) Software Alliance:
+#      contact@openairinterface.org
+################################################################################
+# file install_cassandra
+# brief run script for Cassandra.
+# author  Tien-Thinh NGUYEN
+# company Eurecom
+# email:  tien-thinh.nguyen@eurecom.fr 
+#
+################################
+# include helper functions
+################################
+THIS_SCRIPT_PATH=$(dirname $(readlink -f $0))
+source $THIS_SCRIPT_PATH/../build/tools/build_helper.cassandra
+
+DEFAULT_CASSANDRA_SERVER_IP="127.0.0.1"
+
+
+function help()
+{
+  echo_error " "
+  echo_error "Usage: build_cassandra [OPTION]..."
+  echo_error "Build Cassandra DB"
+  echo_error " "
+  echo_error "Options:"
+  echo_error "Mandatory arguments to long options are mandatory for short options too."
+  echo_error "  -F, --force                               No interactive script for installation of software packages."
+  echo_error "  -h, --help                                Print this help."
+  echo_error "  -i, --check-installed-software            Check installed software packages necessary to build and run Cassandra (support Ubuntu 16.04)."
+  echo_error "  -s, --cassandra-server-ip                 Binding address for cassandra server (default is $DEFAULT_CASSANDRA_SERVER_IP)."
+}
+
+
+function main()
+{
+  local -i verbose=0
+  local -i var_check_install_cassandra_software=0
+  local -i force=0
+  local    realm=""
+  local    cassandra_server_ip=$DEFAULT_CASSANDRA_SERVER_IP
+  local -i change_cassandra_server_ip=0
+
+  until [ -z "$1" ]; do
+    case "$1" in
+      -F | --force)
+        force=1
+        echo "Force set (no interactive)"
+        shift;
+        ;;
+      -h | --help)
+        help
+        exit 0
+        ;;
+      -i | --check-installed-software)
+        echo "Check installed software packages necessary to build and run Cassandra (support Ubuntu 16.04):"
+        set_openair_env
+        var_check_install_cassandra_software=1
+        shift;
+        ;;
+      -s | --cassandra-server-ip)
+        cassandra_server_ip=$2
+        change_cassandra_server_ip=1
+        shift 2;
+        ;;
+      *)   
+        echo "Unknown option $1"
+        help
+        exit 1
+        ;;
+    esac
+  done
+
+  set_openair_env
+
+  if [ ! -d /usr/local/etc/oai ]; then
+    $SUDO mkdir -p /usr/local/etc/oai
+  fi
+  if [ $var_check_install_cassandra_software -gt 0 ];then
+    #Install Java-8 and Cassandra    
+    check_install_cassandra_software $force
+    if [ $? -ne 0 ]; then
+        echo_error "Error: Cassandra installation failed"
+        return 1
+    else
+        echo_success "Cassandra installation successful"
+    fi
+
+    $SUDO cp -upv $OPENAIRCN_DIR/etc/cassandra.conf /usr/local/etc/oai
+    $SUDO sed -i "s|@cassandra_IP@|$cassandra_server_ip|g" /usr/local/etc/oai/cassandra.conf
+    echo_success "Cassandra has been installed successfully."
+    return  0
+  elif [ $change_cassandra_server_ip -gt 0 ];then
+    $SUDO cp -upv $OPENAIRCN_DIR/etc/cassandra.conf /usr/local/etc/oai
+    $SUDO sed -i "s|@cassandra_IP@|$cassandra_server_ip|g" /usr/local/etc/oai/cassandra.conf
+  fi
+  
+  #stop cassandra and clean the log files before modifying the configuration   
+  clean_log_cassandra
+  ret=$?;[[ $ret -ne 0 ]] && return $ret
+  
+  #Update the Cassandra configuration
+  #get Cassandra_Server_IP from the configuration file
+  value="`cat /usr/local/etc/oai/cassandra.conf | cut -d "#" -f1 | grep 'cassandra_server_IP' | tr -d " " | grep "="`"
+  eval $value
+  var_name="cassandra_server_IP"
+  Cassandra_Server_IP=${!var_name}
+  echo "Cassandra_Server_IP=$Cassandra_Server_IP"
+  
+  if [ -f /etc/cassandra/cassandra.yaml ]; then
+    #set values in the configuration file /etc/cassandra/cassandra.yaml
+    $SUDO sed -i "s/'Test Cluster'/'HSS Cluster'/g" /etc/cassandra/cassandra.yaml
+    #set seeds to Cassandra_Server_IP
+    $SUDO sed -i "s/"127.0.0.1"/$Cassandra_Server_IP/g" /etc/cassandra/cassandra.yaml
+    #set listen_address and rpc_address to Cassandra_Server_IP
+    $SUDO sed -i "s/"localhost"/$Cassandra_Server_IP/g" /etc/cassandra/cassandra.yaml
+    #set endpoint_snitch
+    $SUDO sed -i 's/'SimpleSnitch'/'GossipingPropertyFileSnitch'/g' /etc/cassandra/cassandra.yaml
+    #uncomment prefer_local=true in /etc/cassandra/cassandra-rackdc.properties
+    $SUDO sed -i '/prefer_local/s/^#//g' /etc/cassandra/cassandra-rackdc.properties
+  else
+    echo_error "Missing file /etc/cassandra/cassandra.yaml"
+    return 1
+  fi
+  
+  $SUDO service cassandra start   
+  return $?
+}
+
+
+main "$@"
+
+


### PR DESCRIPTION
It seems that a commit in a recent version of the HSS sources has removed the two files necessary to build/rebuild Cassandra. To get a Cassandra installation for the HSS, it is however quite useful to have these scripts. This pull request just adds the missing files, allowing to easily build Cassandra.