### PR TITLE
Adding some Diameter Rel16 AVPs: Extended-***-BM-DL/UL family in diameter patch

### DIFF
--- a/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
+++ b/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
@@ -8,8 +8,8 @@ index 5d74805..f6261ba 100644
 		{
 -			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_REQUIRED, -1, -1 },
 -			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 }
-+           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_OPTIONAL, -1, -1 },
-+           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_OPTIONAL, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_REQUIRED, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 },
 +           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-UL"}, RULE_OPTIONAL, -1, -1 },
 +           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-DL"}, RULE_OPTIONAL, -1, -1 }
 		};

--- a/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
+++ b/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
@@ -1,0 +1,17 @@
+diff --git a/extensions/dict_ts29272_avps/dict_ts29272_avps.c b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+index 5d74805..f6261ba 100644
+--- a/extensions/dict_ts29272_avps/dict_ts29272_avps.c
++++ b/extensions/dict_ts29272_avps/dict_ts29272_avps.c
+@@ -2891,8 +2891,10 @@ static int dict_ts29272_avps_load_rules(char * conffile)
+		CHECK_dict_search(DICT_AVP,  AVP_BY_NAME_AND_VENDOR, &avp_vendor_plus_name, &avp)
+		struct local_rules_definition rules[] =
+		{
+-			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_REQUIRED, -1, -1 },
+-			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 }
++           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_OPTIONAL, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_OPTIONAL, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-Bandwidth-UL"}, RULE_OPTIONAL, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-Bandwidth-DL"}, RULE_OPTIONAL, -1, -1 }
+		};
+		PARSE_loc_rules( rules, avp );
+	  }

--- a/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
+++ b/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
@@ -10,8 +10,116 @@ index 5d74805..f6261ba 100644
 -			{ { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_REQUIRED, -1, -1 }
 +           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-UL"}, RULE_OPTIONAL, -1, -1 },
 +           { { .avp_vendor = 10415, .avp_name = "Max-Requested-Bandwidth-DL"}, RULE_OPTIONAL, -1, -1 },
-+           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-Bandwidth-UL"}, RULE_OPTIONAL, -1, -1 },
-+           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-Bandwidth-DL"}, RULE_OPTIONAL, -1, -1 }
++           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-UL"}, RULE_OPTIONAL, -1, -1 },
++           { { .avp_vendor = 10415, .avp_name = "Extended-Max-Requested-BW-DL"}, RULE_OPTIONAL, -1, -1 }
 		};
 		PARSE_loc_rules( rules, avp );
 	  }
+diff --git a/extensions/dict_ts29214_avps/dict_ts29214_avps.c b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+index 734a5c8..6fd4d7c 100644
+--- a/extensions/dict_ts29214_avps/dict_ts29214_avps.c
++++ b/extensions/dict_ts29214_avps/dict_ts29214_avps.c
+@@ -278,6 +278,102 @@ static int dict_ts29214_avps_load_defs(char * conffile)
+ 			};
+ 			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
+ 		};
++		/* Extended-Max-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				554,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				555,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-DL */
++		{
++			struct dict_avp_data data = {
++				556,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Max-Supported-BW-UL */
++		{
++			struct dict_avp_data data = {
++				557,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Max-Supported-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-DL */
++		{
++			struct dict_avp_data data = {
++				558,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Desired-BW-UL */
++		{
++			struct dict_avp_data data = {
++				559,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Desired-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-DL */
++		{
++			struct dict_avp_data data = {
++				560,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-DL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
++		/* Extended-Min-Requested-BW-UL */
++		{
++			struct dict_avp_data data = {
++				561,	/* Code */
++				10415,	/* Vendor */
++				"Extended-Min-Requested-BW-UL",	/* Name */
++				AVP_FLAG_VENDOR | AVP_FLAG_MANDATORY,	/* Fixed flags */
++				AVP_FLAG_VENDOR,	/* Fixed flag values */
++				AVP_TYPE_UNSIGNED32	/* base type of data */
++			};
++			CHECK_dict_new( DICT_AVP, &data, NULL, NULL);
++		};
+ 		/* Flow-Description */
+ 		{
+ 			struct dict_avp_data data = {
+ 

--- a/build/tools/build_helper
+++ b/build/tools/build_helper
@@ -123,6 +123,7 @@ check_supported_distribution() {
     local distribution=$(get_distribution_release)
     echo "Your distribution is ${distribution}"
     case "$distribution" in
+        "ubuntu20.04") return 0 ;;
         "ubuntu18.04") return 0 ;;
         "ubuntu17.10") return 0 ;;
         "ubuntu17.04") return 0 ;;

--- a/build/tools/build_helper.fd
+++ b/build/tools/build_helper.fd
@@ -415,7 +415,13 @@ install_opencoord.org_freediameter() {
     if ! patch -R -p1 -s -f --dry-run <  $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch; then
           patch -p1 <  $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch
     else
-      echo_info "Detected freeDiameter $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch alredy applied"
+      echo_info "Detected freeDiameter $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch already applied"
+    fi
+    ret=$?;[[ $ret -ne 0 ]] && return $ret
+    if ! patch -R -p1 -s -f --dry-run <  $OPENAIRCN_DIR/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch; then
+          patch -p1 <  $OPENAIRCN_DIR/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
+    else
+      echo_info "Detected freeDiameter $OPENAIRCN_DIR/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch already applied"
     fi
     ret=$?;[[ $ret -ne 0 ]] && return $ret
   

--- a/build/tools/build_helper.hss_rel14
+++ b/build/tools/build_helper.hss_rel14
@@ -33,6 +33,8 @@ build_freeDiameter()
   pushd $OPENAIRCN_DIR/build/git_submodules/freeDiameter
   patch -p1 <  $OPENAIRCN_DIR/build/patches/0001-opencoord.org.freeDiameter.patch
   ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
+  patch -p1 <  $OPENAIRCN_DIR/build/patches/0002-opencoord.org.freeDiameter-ambr-extended-max-requested-bandwidth.patch
+  ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
   rm -rf build
   mkdir -p build
   cd build
@@ -298,11 +300,14 @@ check_install_hss_software() {
   # packages
   if [[ $OS_DISTRO == "ubuntu" ]]; then
     case "$(get_distribution_release)" in
+	"ubuntu20.04")
+	    specific_packages="libgnutls28-dev libgcrypt20-dev "
+	    ;;
 	"ubuntu17.04" | "ubuntu17.10" | "ubuntu18.04")
-	    specific_packages="libgnutls28-dev"
+	    specific_packages="libgnutls28-dev libgcrypt-dev python-cassandra python-blist"
 	    ;;
 	"ubuntu14.04" | "ubuntu16.04")
-	    specific_packages="libgnutls-dev"
+	    specific_packages="libgnutls-dev libgcrypt-dev python-cassandra python-blist"
 	    ;;
     esac
     PACKAGE_LIST="\
@@ -319,15 +324,12 @@ check_install_hss_software() {
       libmemcached-dev \
       memcached \
       cmake-curses-gui \
-      python-cassandra \
       python3-cassandra \
-      python-blist \
       python3-blist \
       gcc \
       bison \
       flex \
       libsctp-dev \
-      libgcrypt-dev \
       libidn11-dev \
       nettle-dev"
   elif [[ "$OS_BASEDISTRO" == "fedora" ]]; then

--- a/docker/Dockerfile.ubuntu18.04
+++ b/docker/Dockerfile.ubuntu18.04
@@ -47,6 +47,10 @@ RUN git config --global http.sslverify false
 WORKDIR /openair-hss
 COPY . .
 
+# wait for it
+workdir /
+RUN git clone https://github.com/vishnubob/wait-for-it.git
+
 # Installing and Building HSS
 WORKDIR /openair-hss/scripts
 RUN ./build_hss_rel14 --check-installed-software --force
@@ -102,6 +106,7 @@ WORKDIR /openair-hss/scripts
 COPY --from=oai-hss-builder /openair-hss/src/hss_rel14/bin/make_certs.sh .
 COPY --from=oai-hss-builder /openair-hss/scripts/data_provisioning_users .
 COPY --from=oai-hss-builder /openair-hss/scripts/data_provisioning_mme .
+COPY --from=oai-hss-builder /wait-for-it/wait-for-it.sh .
 RUN sed -i -e "s@/freeDiameter@@" make_certs.sh
 
 WORKDIR /openair-hss

--- a/scripts/data_provisioning_users
+++ b/scripts/data_provisioning_users
@@ -41,7 +41,26 @@ def str2bool(arg):
     else:
         return False
 
+#---------------------------------------------------------------------
+def ambr2json(br_ul, br_dl):
+    ambr = '"AMBR":'
 
+    if br_ul > 4294967295:
+        max_requested_bandwidth_ul = 4294967295
+        extended_max_requested_bw_ul = br_ul/1000
+        ambr = ambr + '{'+'"Max-Requested-Bandwidth-UL":{0},"Extended-Max-Requested-BW-UL":{1}'.format(max_requested_bandwidth_ul, extended_max_requested_bw_ul)
+    else:
+        ambr = ambr + '{'+'"Max-Requested-Bandwidth-UL":{0}'.format(br_ul)
+      
+    if br_dl > 4294967295:
+        max_requested_bandwidth_dl = 4294967295
+        extended_max_requested_bw_dl = br_dl/1000
+        ambr = ambr + ',"Max-Requested-Bandwidth-DL":{0},"Extended-Max-Requested-BW-DL":{1}'.format(max_requested_bandwidth_dl, extended_max_requested_bw_dl)
+    else:
+        ambr = ambr + ',"Max-Requested-Bandwidth-DL":{0}'.format(br_dl)
+    return ambr+'}'
+
+#---------------------------------------------------------------------
 def main():
 
     logger = logging.getLogger()
@@ -51,6 +70,14 @@ def main():
     parser.add_argument('-a', '--apn',          default='oai.ipv4',            help="default APN allowed for all IMSI of this HSS db")
     parser.add_argument('-A', '--apn2',         default='internet',            help="Non default APN allowed for all IMSI of this HSS db")
     parser.add_argument('-C', '--cassandra-cluster', default='127.0.0.1',      help="Cassandra list of nodes")
+    
+    parser.add_argument('-d', '--apn1-ambr-max-requested-bandwidth-dl', type=int, default=20000000, help="Max requested DL bandwidth in bits per seconds for APN1")
+    parser.add_argument('-D', '--apn2-ambr-max-requested-bandwidth-dl', type=int, default=10000000, help="Max requested DL bandwidth in bits per seconds for APN2")
+    parser.add_argument('-u', '--apn1-ambr-max-requested-bandwidth-ul', type=int, default=10000000, help="Max requested UL bandwidth in bits per seconds for APN1")
+    parser.add_argument('-U', '--apn2-ambr-max-requested-bandwidth-ul', type=int, default=10000000, help="Max requested UL bandwidth in bits per seconds for APN2")
+    parser.add_argument('-e', '--ue-ambr-max-requested-bandwidth-ul', type=int,   default=20000000, help="Max requested UL bandwidth in bits per seconds for UE")
+    parser.add_argument('-E', '--ue-ambr-max-requested-bandwidth-dl', type=int,   default=40000000, help="Max requested DL bandwidth in bits per seconds for UE")
+    
     parser.add_argument('-k', '--key',          default='8baf473f2f8fd09487cccbd7097c6862', help="LTE K (common for all IMSI)=8baf473f2f8fd09487cccbd7097c6862 for OP=11111111111111111111111111111111\n\
                                                                                                 LTE K (common for all IMSI)=fec86ba6eb707ed08905757b1bb44b8f for OP=1006020f0a478bf6b699f15c062e42b3")
     parser.add_argument('-I', '--imsi-first',   default='001010000000001',     help="First IMSI for creating subscribers")
@@ -63,7 +90,7 @@ def main():
     parser.add_argument('-r', '--realm',        default='openair4G.eur',       help="Realm of the CN")
     parser.add_argument('-s', '--static-ue-ipv4-allocation', default=None,     help="UE IPv4 address statically allocated by HSS, disabled if not provided")
     parser.add_argument('-S', '--static-ue-ipv6-allocation', default=None,     help="UE IPv6 address statically allocated by HSS, disabled if not provided")
-    parser.add_argument('-t', '--truncate',     default='False',   choices=['True', 'TRUE', 'true', 'False', 'FALSE', 'false'],           help="Display modified tables")
+    parser.add_argument('-t', '--truncate',     default='False',   choices=['True', 'TRUE', 'true', 'False', 'FALSE', 'false'],           help="Truncate tables, use with caution")
     parser.add_argument('-v', '--verbose',      default='True',    choices=['True', 'TRUE', 'true', 'False', 'FALSE', 'false'],          help="Display modified tables")
     args = parser.parse_args()
 
@@ -81,6 +108,10 @@ def main():
         session.execute("""TRUNCATE vhss.msisdn_imsi ;""")
         session.execute("""TRUNCATE vhss.users_imsi ;""")
 
+    apn1_ambr = ambr2json( args.apn1_ambr_max_requested_bandwidth_ul, args.apn1_ambr_max_requested_bandwidth_dl)
+    apn2_ambr = ambr2json( args.apn2_ambr_max_requested_bandwidth_ul, args.apn2_ambr_max_requested_bandwidth_dl)
+    ue_ambr = ambr2json( args.ue_ambr_max_requested_bandwidth_ul, args.ue_ambr_max_requested_bandwidth_dl)
+    
     imsi_first_int = int(args.imsi_first)
     imsi_length = len(args.imsi_first)
 
@@ -139,7 +170,7 @@ def main():
                 IF NOT EXISTS
                 """,
                 (imsi_str, msisdn, 41, args.key, args.opc, args.mme_identity, 3, args.realm, '2683b376d1056746de3b254012908e0e', args.sqn,
-                '{"Subscription-Data":{"Access-Restriction-Data":41,"Subscriber-Status":0,"Network-Access-Mode":2,"Regional-Subscription-Zone-Code":["0x0123","0x4567","0x89AB","0xCDEF","0x1234","0x5678","0x9ABC","0xDEF0","0x2345","0x6789"],"MSISDN":"0x'+str(msisdn)+'","AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"APN-Configuration-Profile":{"Context-Identifier":0,"All-APN-Configurations-Included-Indicator":0,"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,'+served_party_ip_address+',"Service-Selection":"'+args.apn+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":15,"Pre-emption-Capability":0,"Pre-emption-Vulnerability":0}},"AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}},"APN-Configuration":{"Context-Identifier":1,"PDN-Type":0,'+served_party_ip_address+',"Service-Selection":"'+args.apn2+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":13,"Pre-emption-Capability":1,"Pre-emption-Vulnerability":0}},"AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}}},"Subscribed-Periodic-RAU-TAU-Timer":0}}'
+                '{"Subscription-Data":{"Access-Restriction-Data":41,"Subscriber-Status":0,"Network-Access-Mode":2,"Regional-Subscription-Zone-Code":["0x0123","0x4567","0x89AB","0xCDEF","0x1234","0x5678","0x9ABC","0xDEF0","0x2345","0x6789"],"MSISDN":"0x'+str(msisdn)+'",'+ue_ambr+',"APN-Configuration-Profile":{"Context-Identifier":0,"All-APN-Configurations-Included-Indicator":0,"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,'+served_party_ip_address+',"Service-Selection":"'+args.apn+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":15,"Pre-emption-Capability":0,"Pre-emption-Vulnerability":0}},'+apn1_ambr+',"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}},"APN-Configuration":{"Context-Identifier":1,"PDN-Type":0,'+served_party_ip_address+',"Service-Selection":"'+args.apn2+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":13,"Pre-emption-Capability":1,"Pre-emption-Vulnerability":0}},'+apn2_ambr+',"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}}},"Subscribed-Periodic-RAU-TAU-Timer":0}}'
                 )
             )
         else:
@@ -150,7 +181,7 @@ def main():
                 IF NOT EXISTS
                 """,
                 (imsi_str, msisdn, 41, args.key, args.opc, args.mme_identity, 3, args.realm, '2683b376d1056746de3b254012908e0e', args.sqn,
-                '{"Subscription-Data":{"Access-Restriction-Data":41,"Subscriber-Status":0,"Network-Access-Mode":2,"Regional-Subscription-Zone-Code":["0x0123","0x4567","0x89AB","0xCDEF","0x1234","0x5678","0x9ABC","0xDEF0","0x2345","0x6789"],"MSISDN":"0x'+str(msisdn)+'","AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"APN-Configuration-Profile":{"Context-Identifier":0,"All-APN-Configurations-Included-Indicator":0,"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,"Service-Selection":"'+args.apn+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":15,"Pre-emption-Capability":0,"Pre-emption-Vulnerability":0}},"AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}},"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,"Service-Selection":"'+args.apn2+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":13,"Pre-emption-Capability":1,"Pre-emption-Vulnerability":0}},"AMBR":{"Max-Requested-Bandwidth-UL":50000000,"Max-Requested-Bandwidth-DL":100000000},"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}}},"Subscribed-Periodic-RAU-TAU-Timer":0}}'
+                '{"Subscription-Data":{"Access-Restriction-Data":41,"Subscriber-Status":0,"Network-Access-Mode":2,"Regional-Subscription-Zone-Code":["0x0123","0x4567","0x89AB","0xCDEF","0x1234","0x5678","0x9ABC","0xDEF0","0x2345","0x6789"],"MSISDN":"0x'+str(msisdn)+'",'+ue_ambr+',"APN-Configuration-Profile":{"Context-Identifier":0,"All-APN-Configurations-Included-Indicator":0,"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,"Service-Selection":"'+args.apn+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":15,"Pre-emption-Capability":0,"Pre-emption-Vulnerability":0}},'+apn1_ambr+',"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}},"APN-Configuration":{"Context-Identifier":0,"PDN-Type":0,"Service-Selection":"'+args.apn2+'","EPS-Subscribed-QoS-Profile":{"QoS-Class-Identifier":9,"Allocation-Retention-Priority":{"Priority-Level":13,"Pre-emption-Capability":1,"Pre-emption-Vulnerability":0}},'+apn2_ambr+',"PDN-GW-Allocation-Type":0,"MIP6-Agent-Info":{"MIP-Home-Agent-Address":["172.26.17.183"]}}},"Subscribed-Periodic-RAU-TAU-Timer":0}}'
                 )
             )
 
@@ -174,9 +205,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-
-
-
-
-

--- a/scripts/data_provisioning_users
+++ b/scripts/data_provisioning_users
@@ -47,14 +47,14 @@ def ambr2json(br_ul, br_dl):
 
     if br_ul > 4294967295:
         max_requested_bandwidth_ul = 4294967295
-        extended_max_requested_bw_ul = br_ul/1000
+        extended_max_requested_bw_ul = int(br_ul/1000)
         ambr = ambr + '{'+'"Max-Requested-Bandwidth-UL":{0},"Extended-Max-Requested-BW-UL":{1}'.format(max_requested_bandwidth_ul, extended_max_requested_bw_ul)
     else:
         ambr = ambr + '{'+'"Max-Requested-Bandwidth-UL":{0}'.format(br_ul)
       
     if br_dl > 4294967295:
         max_requested_bandwidth_dl = 4294967295
-        extended_max_requested_bw_dl = br_dl/1000
+        extended_max_requested_bw_dl = int(br_dl/1000)
         ambr = ambr + ',"Max-Requested-Bandwidth-DL":{0},"Extended-Max-Requested-BW-DL":{1}'.format(max_requested_bandwidth_dl, extended_max_requested_bw_dl)
     else:
         ambr = ambr + ',"Max-Requested-Bandwidth-DL":{0}'.format(br_dl)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ mkdir -p /openair-hss/logs
 # Create the certificates
 pushd /openair-hss/scripts
 ./wait-for-it.sh  ${cassandra_Server_IP}:9042
-./data_provisioning_users --apn ${APN1} --apn2 ${APN2} --key ${LTE_K} --imsi-first ${FIRST_IMSI} --msisdn-first 00000001 --mme-identity oai-mme.${REALM} --no-of-users ${NB_USERS} --realm ${REALM} --truncate False --verbose True --cassandra-cluster ${cassandra_Server_IP}
+./data_provisioning_users --ue-ambr-max-requested-bandwidth-ul ${UE_AMBR_UL} --ue-ambr-max-requested-bandwidth-dl ${UE_AMBR_DL} --apn ${APN1} --apn1-ambr-max-requested-bandwidth-dl ${APN1_AMBR_DL} --apn1-ambr-max-requested-bandwidth-ul ${APN1_AMBR_UL} --apn2 ${APN2} --key ${LTE_K} --imsi-first ${FIRST_IMSI} --msisdn-first 00000001 --mme-identity oai-mme.${REALM} --no-of-users ${NB_USERS} --realm ${REALM} --truncate False --verbose True --cassandra-cluster ${cassandra_Server_IP}
 ./data_provisioning_mme --id 3 --mme-identity ${MME_HOSTNAME}.${REALM} --realm ${REALM} --ue-reachability 1 --truncate False  --verbose True -C ${cassandra_Server_IP}
 ./make_certs.sh ${HSS_HOSTNAME} ${REALM} ${PREFIX}
 popd

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -36,6 +36,7 @@ mkdir -p /openair-hss/logs
 
 # Create the certificates
 pushd /openair-hss/scripts
+./wait-for-it.sh  ${cassandra_Server_IP}:9042
 ./data_provisioning_users --apn ${APN1} --apn2 ${APN2} --key ${LTE_K} --imsi-first ${FIRST_IMSI} --msisdn-first 00000001 --mme-identity oai-mme.${REALM} --no-of-users ${NB_USERS} --realm ${REALM} --truncate False --verbose True --cassandra-cluster ${cassandra_Server_IP}
 ./data_provisioning_mme --id 3 --mme-identity ${MME_HOSTNAME}.${REALM} --realm ${REALM} --ue-reachability 1 --truncate False  --verbose True -C ${cassandra_Server_IP}
 ./make_certs.sh ${HSS_HOSTNAME} ${REALM} ${PREFIX}


### PR DESCRIPTION
Actually this PR do not modify anything in the HSS code execution, other PRs will follow.
Tested with dsTester, it does not break a basic attach scenario
Tested on docker/Ubuntu18.04