### PR TITLE
Build fix for renamed branches of dependencies

### DIFF
--- a/build/tools/build_helper.hss_rel14
+++ b/build/tools/build_helper.hss_rel14
@@ -190,7 +190,7 @@ init_submodules()
   local cnt="0"
   while [ $cnt -lt 3 ]
   do
-      git submodule foreach git pull origin master
+      git submodule foreach "git pull origin main || git pull origin master"
       ret=$?
       if [[ $ret -ne 0 ]]
       then


### PR DESCRIPTION
Git repositories of dependencies have recently renamed "master" to "main", which breaks the HSS dependency build with "./build_hss_rel14 --check-installed-software --force". The script calls "git submodule foreach git pull origin master", i.e. the "master" branch is not found any more. Issue: https://github.com/OPENAIRINTERFACE/openair-hss/issues/38 .

This pull request fixes the issue by instead calling:
git submodule foreach "git pull origin main || git pull origin master"
